### PR TITLE
Make API calls compatible with GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Underway::Api.generate_jwt
 You can get an access token for a given installation of your App:
 
 ```ruby
-installations = Underway::Api.invoke("/app/installations")
+installations = Underway::Api.invoke("app/installations")
 access_token = Underway::Api.installation_token(id: installations.first.id)
 ```
 
@@ -107,7 +107,7 @@ To get a list of repositories to which an installation of your App has access,
 try this:
 
 ```ruby
-installations = Underway::Api.invoke("/app/installations")
+installations = Underway::Api.invoke("app/installations")
 access_token = Underway::Api.installation_token(id: installations.first.id)
-repositories = Underway::Api.invoke("/installation/repositories", headers: { authorization: "token #{access_token}" })
+repositories = Underway::Api.invoke("installation/repositories", headers: { authorization: "token #{access_token}" })
 ```

--- a/lib/underway/api.rb
+++ b/lib/underway/api.rb
@@ -49,7 +49,7 @@ module Underway
       else
         log("token cache: miss")
         res = invoke(
-          "/app/installations/#{id}/access_tokens",
+          "app/installations/#{id}/access_tokens",
           method: :post
         )
 

--- a/lib/underway/version.rb
+++ b/lib/underway/version.rb
@@ -1,3 +1,3 @@
 module Underway
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Due to the `api/v3` prefix for GitHub Enterprise, the internal API calls for authentication will fail (along with the examples in the README).