### PR TITLE
Octokit and OAuth URL helpers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+- `Underway::Api.client_for` helper that returns a configured `Octokit` client
+  for a given installation ID or access token
 
 ## [1.0.1] - 2018-05-09
 ### Fixed

--- a/lib/underway/api.rb
+++ b/lib/underway/api.rb
@@ -28,6 +28,20 @@ module Underway
       end
     end
 
+    def self.client_for(installation_id: nil, access_token: nil)
+      token = access_token
+      if !installation_id.nil?
+        token = installation_token(id: installation_id)
+      end
+
+      return if token.nil?
+
+      client = Octokit::Client.new(
+        api_endpoint: Underway::Settings.config.raw["github_api_host"],
+        access_token: token
+      )
+    end
+
     def self.generate_jwt
       payload = {
         # Issued at time:

--- a/lib/underway/settings.rb
+++ b/lib/underway/settings.rb
@@ -1,3 +1,4 @@
+require "addressable/uri"
 require "pathname"
 require "json"
 
@@ -73,6 +74,25 @@ module Underway
 
       def token_cache
         @token_cache ||= Underway::TokenCache.new(db)
+      end
+
+      def oauth_authorize_url
+        uri = Addressable::URI.parse(config["github_api_host"])
+        "#{uri.scheme}://#{uri.domain}/login/oauth/authorize?client_id=#{config["client_id"]}"
+      end
+
+      def oauth_access_token_url(code)
+        api_host = Addressable::URI.parse(config["github_api_host"])
+        template = Addressable::Template.new(
+          "{scheme}://{host}/login/oauth/access_token{?code,client_id,client_secret}"
+        )
+        template.expand(
+          "scheme" => api_host.scheme,
+          "host" => api_host.domain,
+          "code" => code,
+          "client_id" => config["client_id"],
+          "client_secret" => config["client_secret"]
+        )
       end
     end
 

--- a/underway.gemspec
+++ b/underway.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "timecop"
 
+  spec.add_runtime_dependency "addressable", "~> 2.3"
   spec.add_runtime_dependency "jwt", "~> 2.1"
   spec.add_runtime_dependency "octokit", "~> 4.0"
   spec.add_runtime_dependency "sequel"


### PR DESCRIPTION
This branch includes a couple of new helpers for building OAuth URLs for use in the [GitHub App OAuth flow](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/) and a new helper to access a pre-configured Octokit client instance for a given installation or OAuth access token.

Here are some examples of their use:

```ruby
client = Underway::Api.client_for(installation_id: 123456) # returns the Octokit client, configured with the installation token for the given installation token
repositories = client.repositories
```

```ruby
Underway::Settings.config.oauth_authorize_url
# => https://github.com/login/oauth/authorize?client_id=Iv1.abc1234

# => Then, using the code from the OAuth authorize…

Underway::Settings.config.oauth_access_token_url(code)
# => https://github.com/login/oauth/access_token?code=someCode&client_id=Iv1.abc1234&client_secret=configuredClientSecret
```

