### PR TITLE
Support ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,12 @@
 name: Minitest
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,18 +1,22 @@
-name: RSpec
+name: Minitest
 
 on: [push]
 
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        ruby: ["2.7", "3.0"]
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.5
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5.x
+        ruby-version: ${{ matrix.ruby }}
     - name: Build and test with Rake
       run: |
         sudo apt-get install libsqlite3-dev

--- a/lib/underway/sinatra.rb
+++ b/lib/underway/sinatra.rb
@@ -17,8 +17,8 @@ module Sinatra
       end
     end
 
-    def gh_api(*args)
-      ::Underway::Api.invoke(*args)
+    def gh_api(route, **kwargs)
+      ::Underway::Api.invoke(route, **kwargs)
     end
   end
 end

--- a/test/lib/sinatra_test.rb
+++ b/test/lib/sinatra_test.rb
@@ -1,0 +1,30 @@
+require_relative "../test_helper"
+require "underway/sinatra"
+
+class SinatraTest < Minitest::Test
+  include Sinatra::Underway
+
+  def setup
+    Underway::Settings.configure do |config|
+      config.github_api_host = "https://test.example.com"
+    end
+
+    @token = "fake"
+    stub_request(:get, "https://test.example.com/installation/repositories")
+      .with(
+        headers: {
+          "Accept" => "application/vnd.github.machine-man-preview+json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "token #{@token}",
+          "Content-Type" => "application/json",
+          "User-Agent" => "Octokit Ruby Gem #{Octokit::VERSION}"
+        }
+      )
+      .to_return(status: 200, body: {"test" => true}.to_json, headers: {})
+  end
+
+  def test_can_invoke_gh_api_with_kwargs
+    res = gh_api("/installation/repositories", headers: { authorization: "token #{@token}" })
+    refute_nil res
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 require "minitest/autorun"
 require "timecop"
 require "underway"
+require "webmock/minitest"
 require_relative "./sequel_helper.rb"
 
 Timecop.safe_mode = true # Never, NEVER, allow arbitrary mutation of time without a block

--- a/underway.gemspec
+++ b/underway.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "timecop"
+  spec.add_development_dependency "webmock"
 
   spec.add_runtime_dependency "addressable", "~> 2.3"
   spec.add_runtime_dependency "jwt", "~> 2.1"


### PR DESCRIPTION
Hi 👋 ! I was mocking a github app using sinatra using your library and noticed it didn't work with ruby 3.0.

- Fixes one area where kwargs are required now (a warning was printed in 2.7)
- Adds a super simple test to make sure it works with 2.7 and 3.0
- Adds a dev dependency on webmock
- Updates the github workflow to build on both 2.7 and 3.0